### PR TITLE
Fixes for make errors.

### DIFF
--- a/config
+++ b/config
@@ -1,15 +1,9 @@
-textfile /home/gaurav/Work/en.docs.2011/
+textfile /home/vivek/Downloads/FIREData/2011/en.docs.2011/en_BDNews24/1/
 language english
-db /home/gaurav/Work/xapiantrec/index_withstopword1
-resultsfile /home/gaurav/Work/xapiantrec/testindexingwithstopword
-transfile /home/gaurav/Work/xapiantrec/transactionindexingwithstopword1
-topicfile /home/gaurav/Work/xapiantrec/queries_english1
-queryfile /home/gaurav/Work/xapiantrec/query_withstopword
-relfile /home/gaurav/Work/xapiantrec/en_qrel1
+db /home/vivek/Downloads/FIREData/2011/en.docs.2011/index_business/
 runname xapiantrecwithstopword
-stopsfile stopfile
-noresults 200
-evaluationfiles /home/gaurav/Work/xapiantrec/evaluationwithstopword
+stopsfile /home/vivek/Downloads/FIREData/2011/en.docs.2011/stopwords.txt
+noresults 300
 indexbigram true
 queryparsebigram true
 weightingscheme lmweight
@@ -17,4 +11,3 @@ lmparam_log  0.0
 lmparam_select_smoothing TWO_STAGE_SMOOTHING
 lmparam_smoothing1 0.9
 lmparam_smoothing2 2000.0
-lmparam_mixture 1.0

--- a/src/trec_index.cc
+++ b/src/trec_index.cc
@@ -352,7 +352,7 @@ int main(int argc, char **argv)
     // Catch any Xapian::Error exceptions thrown
     try {
         // Make the database
-        Xapian::WritableDatabase db("/home/vivek/Downloads/FIREData/2011/en.docs.2011/index_business/", Xapian::DB_CREATE_OR_OPEN);
+        Xapian::WritableDatabase db(Xapian::Chert::open(trec_config.get_db().c_str(), Xapian::DB_CREATE_OR_OPEN));
 
 				struct timeval start_time, finish_time, timelapse;   /* timing variables */
 

--- a/src/trec_index.cc
+++ b/src/trec_index.cc
@@ -256,9 +256,6 @@ static void index_file( const string &file,
       Xapian::SimpleStopper stopper;
 	  get_stopper(stopper,config);
 	  indexer.set_stopper(&stopper);
-	  if ( config.get_indexbigram() ) {
-		indexer.set_bigrams(true);
-	  }
       // Add postings for terms to the document
       Xapian::Document doc;
 	  doc.set_data(p.title);

--- a/src/trec_index.cc
+++ b/src/trec_index.cc
@@ -352,7 +352,7 @@ int main(int argc, char **argv)
     // Catch any Xapian::Error exceptions thrown
     try {
         // Make the database
-        Xapian::WritableDatabase db(Xapian::Brass::open(trec_config.get_db().c_str(), Xapian::DB_CREATE_OR_OPEN));
+        Xapian::WritableDatabase db("/home/vivek/Downloads/FIREData/2011/en.docs.2011/index_business/", Xapian::DB_CREATE_OR_OPEN);
 
 				struct timeval start_time, finish_time, timelapse;   /* timing variables */
 

--- a/src/trec_search.cc
+++ b/src/trec_search.cc
@@ -156,15 +156,6 @@ int main(int argc, char **argv)
 			enquire.set_weighting_scheme(Xapian::TradWeight());
 		}
  	}
-	else if (config.use_weightingscheme("lmweight")) {
-		cout<<"Config Check LM"<<config.check_lmweight()<<endl;
-		if (config.check_lmweight()) {
-			enquire.set_weighting_scheme(Xapian::LMWeight(config.get_lmparam_log(),config.get_lmparam_select_smoothing(),config.get_lmparam_smoothing1(),config.get_lmparam_smoothing2(),config.get_lmparam_mixture()));
-		}
-		else {
-			enquire.set_weighting_scheme(Xapian::LMWeight());
-		}
-	}
 	else if (config.use_weightingscheme("boolweight")) {
 		enquire.set_weighting_scheme(Xapian::BoolWeight());
 	}

--- a/src/trec_search.cc
+++ b/src/trec_search.cc
@@ -156,6 +156,15 @@ int main(int argc, char **argv)
 			enquire.set_weighting_scheme(Xapian::TradWeight());
 		}
  	}
+ 	else if (config.use_weightingscheme("lmweight")) {
+		cout<<"Config Check LM"<<config.check_lmweight()<<endl;
+		if (config.check_lmweight()) {
+			enquire.set_weighting_scheme(Xapian::LMWeight(config.get_lmparam_log(),config.get_lmparam_select_smoothing(),config.get_lmparam_smoothing1(),config.get_lmparam_smoothing2()));
+		}
+		else {
+			enquire.set_weighting_scheme(Xapian::LMWeight());
+		}
+	}
 	else if (config.use_weightingscheme("boolweight")) {
 		enquire.set_weighting_scheme(Xapian::BoolWeight());
 	}

--- a/src/trec_search.cc
+++ b/src/trec_search.cc
@@ -61,8 +61,7 @@ int load_query( std::ifstream & queryfile, int & topicno,Xapian::Query & query, 
 	Xapian::SimpleStopper stopper;
 	get_stopper(stopper);
 	qp.set_stopper(&stopper);
-	qp.set_stemmer(stemmer);
-	qp.set_bigram(config.get_queryparsebigram());  
+	qp.set_stemmer(stemmer);  
 	qp.set_stemming_strategy(Xapian::QueryParser::STEM_SOME);
 	query = qp.parse_query(line);
 	cout<<"Parsed Query is :\t"<<query.get_description()<<endl;


### PR DESCRIPTION
@samuelharden Please verify the changes that I made to fix make errors. Might give us a clue for why indexing is still failing with segmentation fault error on my system. My best guess is that something is odd in `trec_index.cc` that might be causing indexing to fail. It successfully decompresses documents in directory specified by `textfile` parameter i.e. `./en.docs.2011/en_BDNews24/1/`